### PR TITLE
Comment out misleading notice from scrypt import

### DIFF
--- a/lib/blockchain.py
+++ b/lib/blockchain.py
@@ -28,12 +28,12 @@ from . import bitcoin
 from .bitcoin import *
 import lyra2z_hash
 
-try:
-    import scrypt
-    getPoWHash = lambda x: scrypt.hash(x, x, N=1024, r=1, p=1, buflen=32)
-except ImportError:
-    util.print_msg("Warning: package scrypt not available; synchronization could be very slow")
-    from .scrypt import scrypt_1024_1_1_80 as getPoWHash
+# try:
+#     import scrypt
+#     getPoWHash = lambda x: scrypt.hash(x, x, N=1024, r=1, p=1, buflen=32)
+# except ImportError:
+#     util.print_msg("Warning: package scrypt not available; synchronization could be very slow")
+#     from .scrypt import scrypt_1024_1_1_80 as getPoWHash
 
 MAX_TARGET = 0x00000FFFFF000000000000000000000000000000000000000000000000000000
 HF_LYRA2VAR_HEIGHT = 500


### PR DESCRIPTION
Remove the line below
<strike>`Warning: package scrypt not available; synchronization could be very slow`</strike>

```
./electrum-xzc getbalance
Warning: package scrypt not available; synchronization could be very slow
{
    "confirmed": "0"
}
```