### PR TITLE
Allow lower fees

### DIFF
--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1093,12 +1093,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         def on_fee_or_feerate(edit_changed, editing_finished):
             edit_other = self.feerate_e if edit_changed == self.fee_e else self.fee_e
-            if editing_finished:
-                if not edit_changed.get_amount():
-                    # This is so that when the user blanks the fee and moves on,
-                    # we go back to auto-calculate mode and put a fee back.
-                    edit_changed.setModified(False)
-            else:
+            if not editing_finished:
                 # edit_changed was edited just now, so make sure we will
                 # freeze the correct fee setting (this)
                 edit_other.setModified(False)

--- a/gui/qt/main_window.py
+++ b/gui/qt/main_window.py
@@ -1491,9 +1491,10 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         if use_rbf:
             tx.set_rbf(True)
 
-        if fee < self.wallet.relayfee() * tx.estimated_size() / 1000:
-            self.show_error(_("This transaction requires a higher fee, or it will not be propagated by the network"))
-            return
+        # Network allows transactions with any fees ATM. Alow user to set them as low 1 satoshi/byte.
+        # if fee < self.wallet.relayfee() * tx.estimated_size() / 1000:
+        #     self.show_error(_("This transaction requires a higher fee, or it will not be propagated by the network"))
+        #     return
 
         if preview:
             self.show_transaction(tx, tx_desc)


### PR DESCRIPTION
Network allows transactions with any fees ATM. Alow user to set them manually as low 1 zeetoshi/byte. Default is still 100 zeetoshi/byte and slider does not go below this, but if user enabled manual fees in preferences, he can enter lower value.