### PR TITLE
Fix Zcoin WIF prefix

### DIFF
--- a/lib/bitcoin.py
+++ b/lib/bitcoin.py
@@ -89,7 +89,7 @@ class NetworkConstants:
     @classmethod
     def set_mainnet(cls):
         cls.TESTNET = False
-        cls.WIF_PREFIX = 0x80
+        cls.WIF_PREFIX = 210
         cls.ADDRTYPE_P2PKH = 82  # 0x52
         cls.ADDRTYPE_P2SH = 7  # 0x07
         cls.SEGWIT_HRP = "xzc"
@@ -527,10 +527,10 @@ def DecodeBase58Check(psz):
 # extended key export format for segwit
 
 SCRIPT_TYPES = {
-    'p2pkh':82,
+    'p2pkh':0,
     'p2wpkh':1,
     'p2wpkh-p2sh':2,
-    'p2sh':7,
+    'p2sh':5,
     'p2wsh':6,
     'p2wsh-p2sh':7
 }


### PR DESCRIPTION
Also fixes display of script type for multisig addresses (right click on address, select "private key", without this patch it displays p2wsh-p2sh, instead of p2sh)